### PR TITLE
Rename the "test" workflow to "ci"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: test
+name: ci
 on:
   pull_request:
   push:


### PR DESCRIPTION
This should fix the broken badge in the README.

Signed-off-by: Jonathan Hartman <j@hartman.io>